### PR TITLE
log-*-and-return

### DIFF
--- a/src/drtom/logbug/debug.clj
+++ b/src/drtom/logbug/debug.clj
@@ -85,3 +85,16 @@
   (logging/log ns :debug nil x)
   x)
 
+;### log expression and return its value ######################################
+
+(defn log-debug-and-return [expr]
+  (do (logging/debug expr) expr))
+
+(defn log-info-and-return [expr]
+  (do (logging/info expr) expr))
+
+(defn log-warn-and-return [expr]
+  (do (logging/warn expr) expr))
+
+(defn log-error-and-return [expr]
+  (do (logging/error expr) expr))


### PR DESCRIPTION
Can be a function and use `do` as the argument is evaluated (once) when passed to it anyway, so no worries for multiple evaluation (and possibly side-effects). At least I could not observe any troubles.
