### PR TITLE
4.2.0 debug/with-logging [func x] 

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject logbug "4.1.0"
+(defproject logbug "4.2.0"
   :description "Cross-cutting utilities for logging and debugging in Clojure."
   :url "https://github.com/drtom/clj-logbug"
   :license {:name "Dual: EPL and LGPL"}

--- a/src/logbug/debug.clj
+++ b/src/logbug/debug.clj
@@ -80,12 +80,20 @@
 
 (defmacro identity-with-logging
   ([x]
-   `(identity-with-logging ~*ns* ~x))
+   `(identity-with-logging *ns* ~x))
   ([ns x]
-   `(let [result# ~x]
-      (logging/log ~ns :debug nil (if (seq? result#) (doall (seq result#)) result#))
-      result#)))
+   `(with-logging ~ns identity ~x)))
 
+;### with-logging ns ##########################################################
+
+(defmacro with-logging
+  ([func x]
+   `(with-logging ~*ns* ~func ~x))
+  ([ns func x]
+   `(let [result# ~x
+          func-result# (~func result#)]
+      (logging/log ~ns :debug nil func-result#)
+      result#)))
 
 ;### interleave ###############################################################
 


### PR DESCRIPTION
I have many times found myself in situations where I needed to apply a particular function to the result before logging it, which was not possible with `identity-with-logging`.

I have created a new, more general macro `with-logging` where one is able to pass a `fn` to be applied to the result before it is logged. The result before the function application is returned after the evaluation of the expanded form as usual.

Thus, `identity-with-logging` is now a specialized form of the former as: `(with-logging identity ...)`.

I removed your "workaround" for `seq`s from the macro definition. The problem you had with `seq`s can now be solved as: `(with-logging (doall a-seq) a-seq)`. Any other problem in future in regards to evaluating/printing prior to logging can be solved this way.
